### PR TITLE
Add #try method with tests

### DIFF
--- a/lib/strict_open_struct.rb
+++ b/lib/strict_open_struct.rb
@@ -19,4 +19,12 @@ class StrictOpenStruct
   def ==(other)
     @open_struct == other.instance_variable_get("@open_struct")
   end
+
+  def try(method)
+    begin
+      self.send(method)
+    rescue NoMethodError
+      nil
+    end
+  end
 end

--- a/test/basic_test.rb
+++ b/test/basic_test.rb
@@ -46,5 +46,15 @@ describe StrictOpenStruct do
     end
   end
 
+  describe "#try" do
+    specify "returns correct result if method exists" do
+      assert_equal StrictOpenStruct.new(a: 'a').try(:a), 'a'
+    end
+
+    specify "returns nil if method doesn't exist" do
+      assert_equal StrictOpenStruct.new(a: 'a').try(:b), nil
+    end
+  end
+
 end
 


### PR DESCRIPTION
@naw was wrestling with a bug for a while until I realized Rails's `:try` doesn't seem to play nicely with `StrictOpenStruct`. This makes it so we can use `try` on `StrictOpenStruct` instances.
